### PR TITLE
Fixed style for SmoothScrollViewer

### DIFF
--- a/src/Wpf.Ui.Violeta/Controls/SmoothScrollViewer/SmoothScrollViewer.xaml
+++ b/src/Wpf.Ui.Violeta/Controls/SmoothScrollViewer/SmoothScrollViewer.xaml
@@ -3,7 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:Wpf.Ui.Violeta.Controls">
 
-    <Style BasedOn="{StaticResource DefaultScrollViewerStyle}" TargetType="{x:Type local:SmoothScrollViewer}">
+    <Style BasedOn="{StaticResource UiScrollViewer}" TargetType="{x:Type local:SmoothScrollViewer}">
         <Setter Property="PanningMode" Value="Both" />
     </Style>
 


### PR DESCRIPTION
When using SmoothScrollViewer an exception is thrown because it doesn't find the `DefaultScrollViewerStyle` resource. Changed it to `UiScrollViewer` from WPF.UI to work.