### PR TITLE
Button.xaml：将Appearance触发器移至Style级以支持LoadingButton继承

### DIFF
--- a/src/Wpf.Ui.Violeta/Hotfix/Button.xaml
+++ b/src/Wpf.Ui.Violeta/Hotfix/Button.xaml
@@ -80,161 +80,10 @@
                         </Border>
                     </Border>
                     <ControlTemplate.Triggers>
-                        <!--  TRANSPARENT  -->
-                        <Trigger Property="Appearance" Value="Transparent">
-                            <Setter Property="Background" Value="Transparent" />
-                        </Trigger>
-
-                        <!--  PRIMARY  -->
-                        <Trigger Property="Appearance" Value="Primary">
-                            <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
-                            <Setter Property="MouseOverBackground" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
-                            <Setter Property="PressedBackground" Value="{DynamicResource AccentButtonBackgroundPressed}" />
-                            <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
-                            <Setter Property="PressedForeground" Value="{DynamicResource AccentButtonForegroundPointerOver}" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                            <Setter Property="PressedBorderBrush" Value="{DynamicResource ControlFillColorTransparentBrush}" />
-                        </Trigger>
-
                         <!--  SECONDARY  -->
                         <Trigger Property="Appearance" Value="Secondary">
                             <Setter TargetName="InsetBorder" Property="BorderThickness" Value="0" />
                             <Setter TargetName="ContentBorder" Property="BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}}" />
-                        </Trigger>
-
-                        <!--  DARK  -->
-                        <Trigger Property="Appearance" Value="Dark">
-                            <Setter Property="Background">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource ControlStrongFillColorDark}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="MouseOverBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="#62000000" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="#52000000" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBorderBrush" Value="Transparent" />
-                            <Setter Property="Foreground" Value="{DynamicResource TextFillColorLightPrimaryBrush}" />
-                            <Setter Property="PressedForeground" Value="{DynamicResource TextFillColorLightSecondaryBrush}" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                        </Trigger>
-
-                        <!--  LIGHT  -->
-                        <Trigger Property="Appearance" Value="Light">
-                            <Setter Property="Background">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource ControlStrongFillColorLight}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="MouseOverBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="#D3FFFFFF" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="#F3FFFFFF" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="Foreground" Value="{DynamicResource TextFillColorDarkPrimaryBrush}" />
-                            <Setter Property="PressedForeground" Value="{DynamicResource TextFillColorDarkSecondaryBrush}" />
-                        </Trigger>
-
-                        <!--  INFO  -->
-                        <Trigger Property="Appearance" Value="Info">
-                            <Setter Property="Background">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource PaletteLightBlueColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="MouseOverBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteLightBlueColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteLightBlueColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="Foreground" Value="{DynamicResource TextFillColorLightPrimaryBrush}" />
-                            <Setter Property="PressedBorderBrush" Value="Transparent" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                        </Trigger>
-
-                        <!--  DANGER  -->
-                        <Trigger Property="Appearance" Value="Danger">
-                            <Setter Property="Background">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource PaletteRedColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="MouseOverBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteRedColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteRedColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBorderBrush" Value="Transparent" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                        </Trigger>
-
-                        <!--  SUCCESS  -->
-                        <Trigger Property="Appearance" Value="Success">
-                            <Setter Property="Background">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource PaletteGreenColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="MouseOverBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteGreenColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteGreenColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBorderBrush" Value="Transparent" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                        </Trigger>
-
-                        <!--  CAUTION  -->
-                        <Trigger Property="Appearance" Value="Caution">
-                            <Setter Property="Background">
-                                <Setter.Value>
-                                    <SolidColorBrush Color="{DynamicResource PaletteOrangeColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="MouseOverBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteOrangeColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBackground">
-                                <Setter.Value>
-                                    <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteOrangeColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="PressedBorderBrush" Value="Transparent" />
-                            <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
-                            <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
                         </Trigger>
 
                         <!--  SHARED TRIGGERS  -->
@@ -278,8 +127,161 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+
+        <!--  Appearance triggers at Style level so child styles (e.g. LoadingButton) inherit them via BasedOn.  -->
+        <Style.Triggers>
+            <!--  TRANSPARENT  -->
+            <Trigger Property="Appearance" Value="Transparent">
+                <Setter Property="Background" Value="Transparent" />
+            </Trigger>
+
+            <!--  PRIMARY  -->
+            <Trigger Property="Appearance" Value="Primary">
+                <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
+                <Setter Property="MouseOverBackground" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
+                <Setter Property="PressedBackground" Value="{DynamicResource AccentButtonBackgroundPressed}" />
+                <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
+                <Setter Property="PressedForeground" Value="{DynamicResource AccentButtonForegroundPointerOver}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                <Setter Property="PressedBorderBrush" Value="{DynamicResource ControlFillColorTransparentBrush}" />
+            </Trigger>
+
+            <!--  DARK  -->
+            <Trigger Property="Appearance" Value="Dark">
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush Color="{DynamicResource ControlStrongFillColorDark}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="MouseOverBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Color="#62000000" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Color="#52000000" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBorderBrush" Value="Transparent" />
+                <Setter Property="Foreground" Value="{DynamicResource TextFillColorLightPrimaryBrush}" />
+                <Setter Property="PressedForeground" Value="{DynamicResource TextFillColorLightSecondaryBrush}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+            </Trigger>
+
+            <!--  LIGHT  -->
+            <Trigger Property="Appearance" Value="Light">
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush Color="{DynamicResource ControlStrongFillColorLight}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="MouseOverBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Color="#D3FFFFFF" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Color="#F3FFFFFF" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Foreground" Value="{DynamicResource TextFillColorDarkPrimaryBrush}" />
+                <Setter Property="PressedForeground" Value="{DynamicResource TextFillColorDarkSecondaryBrush}" />
+            </Trigger>
+
+            <!--  INFO  -->
+            <Trigger Property="Appearance" Value="Info">
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush Color="{DynamicResource PaletteLightBlueColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="MouseOverBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteLightBlueColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteLightBlueColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Foreground" Value="{DynamicResource TextFillColorLightPrimaryBrush}" />
+                <Setter Property="PressedBorderBrush" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+            </Trigger>
+
+            <!--  DANGER  -->
+            <Trigger Property="Appearance" Value="Danger">
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush Color="{DynamicResource PaletteRedColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="MouseOverBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteRedColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteRedColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBorderBrush" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+            </Trigger>
+
+            <!--  SUCCESS  -->
+            <Trigger Property="Appearance" Value="Success">
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush Color="{DynamicResource PaletteGreenColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="MouseOverBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteGreenColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteGreenColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBorderBrush" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+            </Trigger>
+
+            <!--  CAUTION  -->
+            <Trigger Property="Appearance" Value="Caution">
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush Color="{DynamicResource PaletteOrangeColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="MouseOverBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Opacity="0.9" Color="{DynamicResource PaletteOrangeColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBackground">
+                    <Setter.Value>
+                        <SolidColorBrush Opacity="0.7" Color="{DynamicResource PaletteOrangeColor}" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="PressedBorderBrush" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+                <Setter Property="MouseOverBorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style BasedOn="{StaticResource DefaultUiButtonStyle}" TargetType="{x:Type controls:Button}" />
-
 </ResourceDictionary>


### PR DESCRIPTION
将针对不同Appearance的样式触发器从ControlTemplate.Triggers迁移到Style.Triggers，便于子样式继承和复用，提升可维护性。原模板仅保留控件状态相关触发器。